### PR TITLE
Tweak parsing configurations to Option Object pattern rather than parsing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,49 +22,65 @@ npm install vcommand-parser
 To use this utility, you can simply use the static functions provided by the `VCommandParser` class :
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import parseMessage from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('!command');
+const parsedCommand = parseMessage('!command');
 ```
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import parseMessage from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('!command --option');
+const parsedCommand = parseMessage('!command --option');
 ```
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import parseMessage from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('!command -abc');
+const parsedCommand = parseMessage('!command -abc');
 ```
 
 In the last example above, there is three "short" options : `["a", "b", "c"]`.
 
+The default function `parseMessage` is an alias of the `VCommandParser.parse` static method. You can achieve the same result with this notation, depending on your preferences :
+
+```typescript
+import { VCommandParser } from 'vcommand-parser';
+
+const parsedCommand = VCommandParser.parse('!command');
+```
+
 The default command prefix is `!` and the default option prefix is `-`, which are both configurable, as shown below :
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('\\command', '\\');
+const parsedCommand = VCommandParser.parse('\\command', {
+    commandPrefix: '\\'
+});
 ```
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('\\command ~~option', '\\', '~');
+const parsedCommand = VCommandParser.parse('\\command ~~option', {
+    commandPrefix: '\\',
+    optionPrefix: '~'
+});
 ```
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
-const parsedCommand = VCommandParser.parse('\\command ~abc', '\\', '~');
+const parsedCommand = VCommandParser.parse('\\command ~abc', {
+    commandPrefix: '\\',
+    optionPrefix: '~'
+});
 ```
 
 ### Dealing with parsed object
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
 const parsedCommand = VCommandParser.parse('!command --option');
 
@@ -98,7 +114,7 @@ VParsedCommand {
 ### Dealing with parsed object and content
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
 const parsedCommand = VCommandParser.parse('!command content --option "option content"');
 
@@ -134,7 +150,7 @@ Note in this example : since `"option content"` has a space in its content, you 
 ### Accessing options
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
 const parsedCommand = VCommandParser.parse('!command content --option "option content"');
 
@@ -180,7 +196,7 @@ const definitions = [
   new OptionDef(['s', 'short'], {description: 'This is my short description', weight: 2})
 ];
 
-const parsedCommand = VCommandParser.parse('!command content -l "option content"', undefined, undefined, definitions);
+const parsedCommand = VCommandParser.parse('!command content -l "option content"', {optionDefinitions: definitions});
 
 console.log(parsedCommand);
 ```
@@ -237,7 +253,7 @@ new OptionDef('l', {description: 'This is my long description', acceptsContent: 
 
 ### Defining options lazily
 
-You may sometimes prefer to define the definitions after a basic parsing to get the command name and potentially the content too. You therefore have access to another static function in `VCommandParser` :
+You may sometimes prefer to define the definitions after a basic parsing to get the command name and potentially the content too. You can therefore use the option `lazy` to get this behavior :
 
 ```typescript
 import { VCommandParser, OptionDef } from 'vcommand-parser';
@@ -247,7 +263,7 @@ const definitions = [
   new OptionDef(['s', 'short'], {description: 'This is my short description', weight: 2})
 ];
 
-const parsedCommand = VCommandParser.parseLazy('!command content -l "option content"');
+const parsedCommand = VCommandParser.parse('!command content -l "option content"', {lazy: true});
 
 console.log(parsedCommand.command); // 'command'
 console.log(parsedCommand.content); // 'content -l "option content"'
@@ -269,7 +285,7 @@ The variable `parsedCommand` will therefore contain the same definitions as if y
 This package automatically determines if the given string is a command or not based on if the messages starts with the given command prefix.
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
 const parsedCommand = VCommandParser.parse('this is a message');
 
@@ -294,7 +310,7 @@ VParsedCommand {
 When the message is not a command, options aren't parsed :
 
 ```typescript
-import VCommandParser from 'vcommand-parser';
+import { VCommandParser } from 'vcommand-parser';
 
 const parsedCommand = VCommandParser.parse('this is --a message');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import OptionPrefix from './@types/OptionPrefix';
 import MessageOption from './message-option';
 import OptionDef from './option-def';
-import VCommandParser from './vcommandparser';
+import { default as parseMessage, VCommandParser } from './vcommandparser';
 import { VLazyParsedCommand, VParsedCommand } from './vparsedcommand';
 
 export {
+	parseMessage,
 	VCommandParser,
 	VParsedCommand,
 	VLazyParsedCommand,
@@ -13,4 +14,4 @@ export {
 	MessageOption
 };
 
-export default VCommandParser;
+export default parseMessage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import OptionPrefix from './@types/OptionPrefix';
 import MessageOption from './message-option';
 import OptionDef from './option-def';
-import { VCommandParser, VLazyParsedCommand, VParsedCommand } from './vcommandparser';
+import VCommandParser from './vcommandparser';
+import { VLazyParsedCommand, VParsedCommand } from './vparsedcommand';
 
 export {
 	VCommandParser,

--- a/src/message-option.ts
+++ b/src/message-option.ts
@@ -1,6 +1,6 @@
 import OptionDef from './option-def';
 
-export default class MessageOption {
+export class MessageOption {
 	readonly name: string;
 	readonly content?: string;
 	
@@ -15,3 +15,5 @@ export default class MessageOption {
 		this.definition = definition;
 	}
 }
+
+export default MessageOption;

--- a/src/message-parser.ts
+++ b/src/message-parser.ts
@@ -2,9 +2,11 @@ import { ParsedValue, splitSpacesExcludeQuotesDetailed } from 'quoted-string-spa
 import OptionPrefix from './@types/OptionPrefix';
 import MessageOption from './message-option';
 import OptionDef from './option-def';
+import { RequiredParserOptions, verifyParserOptionsIsNonLazy, VLazyParserOptions, VParserOptions } from './vcommandparser';
 
-export type ParsedMessage = {
+export type VParsedMessage<T extends VLazyParserOptions | VParserOptions> = {
 	isCommand: boolean;
+	parserOptions: T;
 	command?: string;
 	fullContent?: string;
 	content?: string;
@@ -12,15 +14,19 @@ export type ParsedMessage = {
 	duplicatedOptions?: MessageOption[];
 }
 
-export function parseMessage(message: string, commandPrefix: string, optionPrefix: OptionPrefix, optionDefinitions?: OptionDef[], isLazy = false): ParsedMessage {
-	const extractedData = extractCommandAndContent(message, commandPrefix);
+// export default function parseMessage(message: string, commandPrefix: string, optionPrefix: OptionPrefix, optionDefinitions?: OptionDef[], isLazy = false): ParsedMessage {
+export function parseMessage(message: string, parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>> {
+	const extractedData = extractCommandAndContent(message, parserOptions.commandPrefix);
 	
-	const extractedOptions: ParsedOptions | Record<string, unknown> = extractedData.isCommand && !isLazy && extractedData.content ? extractOptionsFromParsedContent(extractedData.content, optionPrefix, optionDefinitions) : {};
+	const extractedOptions: ParsedOptions | Record<string, unknown> = verifyParserOptionsIsNonLazy(parserOptions) && extractedData.isCommand && extractedData.content
+		? extractOptionsFromParsedContent(extractedData.content, parserOptions.optionPrefix, parserOptions.optionDefinitions)
+		: {};
 	
 	const parsedMessage = {
 		fullContent: extractedData.content,
+		parserOptions: parserOptions,
 		...extractedData,
-		...extractedOptions
+		...extractedOptions,
 	};
 	
 	return parsedMessage;

--- a/src/message-parser.ts
+++ b/src/message-parser.ts
@@ -12,9 +12,7 @@ export type ParsedMessage = {
 	duplicatedOptions?: MessageOption[];
 }
 
-export { parseMessage };
-
-export default function parseMessage(message: string, commandPrefix: string, optionPrefix: OptionPrefix, optionDefinitions?: OptionDef[], isLazy = false): ParsedMessage {
+export function parseMessage(message: string, commandPrefix: string, optionPrefix: OptionPrefix, optionDefinitions?: OptionDef[], isLazy = false): ParsedMessage {
 	const extractedData = extractCommandAndContent(message, commandPrefix);
 	
 	const extractedOptions: ParsedOptions | Record<string, unknown> = extractedData.isCommand && !isLazy && extractedData.content ? extractOptionsFromParsedContent(extractedData.content, optionPrefix, optionDefinitions) : {};
@@ -161,3 +159,5 @@ export function extractOptionsFromParsedContent(content: string, optionPrefix: O
 		duplicatedOptions: duplicatedOptions.length ? duplicatedOptions : undefined
 	};
 }
+
+export default parseMessage;

--- a/src/message-parser.ts
+++ b/src/message-parser.ts
@@ -14,7 +14,7 @@ export type VParsedMessage<T extends VLazyParserOptions | VParserOptions> = {
 	duplicatedOptions?: MessageOption[];
 }
 
-export function parseMessage(message: string, parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>> {
+export function doParseMessage(message: string, parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>> {
 	const extractedData = extractCommandAndContent(message, parserOptions.commandPrefix);
 	
 	const extractedOptions: ParsedOptions | Record<string, unknown> = verifyParserOptionsIsNonLazy(parserOptions) && extractedData.isCommand && extractedData.content
@@ -165,4 +165,4 @@ export function extractOptionsFromParsedContent(content: string, optionPrefix: O
 	};
 }
 
-export default parseMessage;
+export default doParseMessage;

--- a/src/message-parser.ts
+++ b/src/message-parser.ts
@@ -14,7 +14,6 @@ export type VParsedMessage<T extends VLazyParserOptions | VParserOptions> = {
 	duplicatedOptions?: MessageOption[];
 }
 
-// export default function parseMessage(message: string, commandPrefix: string, optionPrefix: OptionPrefix, optionDefinitions?: OptionDef[], isLazy = false): ParsedMessage {
 export function parseMessage(message: string, parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>> {
 	const extractedData = extractCommandAndContent(message, parserOptions.commandPrefix);
 	

--- a/src/option-def.ts
+++ b/src/option-def.ts
@@ -1,10 +1,10 @@
-type OptionBehavior = {
+export type OptionBehavior = {
 	acceptsContent: boolean,
 	weight: number,
 	description?: string,
 }
 
-export default class OptionDef {
+export class OptionDef {
 	static readonly DEFAULT_WEIGHT = 0;
 	
 	readonly calls: string[];
@@ -32,3 +32,5 @@ export default class OptionDef {
 		} = finalOptions);
 	}
 }
+
+export default OptionDef;

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -17,11 +17,11 @@ export interface VCommonParserOptions {
 	 */
 	optionPrefix?: OptionPrefix;
 	
-	isLazy?: boolean;
+	lazy?: boolean;
 }
 
 export interface VLazyParserOptions extends VCommonParserOptions {
-	isLazy?: true;
+	lazy?: true;
 	
 	/**
 	 * Function to return the array of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
@@ -30,7 +30,7 @@ export interface VLazyParserOptions extends VCommonParserOptions {
 }
 
 export interface VParserOptions extends VCommonParserOptions {
-	isLazy?: false;
+	lazy?: false;
 	
 	/**
 	 * Array of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
@@ -44,14 +44,14 @@ function mergeWithDefaultParserOptions<T extends VCommonParserOptions>(parserOpt
 	const defaultOptions: Required<VCommonParserOptions> = {
 		commandPrefix: VCommandParser.DEFAULT_COMMAND_PREFIX,
 		optionPrefix: VCommandParser.DEFAULT_OPTION_PREFIX,
-		isLazy: false,
+		lazy: false,
 	};
 	
 	return {...defaultOptions, ...parserOptions};
 }
 
 export function verifyParserOptionsIsNonLazy(parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): parserOptions is Required<VCommonParserOptions> & VParserOptions {
-	return !parserOptions.isLazy && (parserOptions.optionDefinitions == undefined || Array.isArray(parserOptions.optionDefinitions));
+	return !parserOptions.lazy && (parserOptions.optionDefinitions == undefined || Array.isArray(parserOptions.optionDefinitions));
 }
 function verifyParsedCommandType(parsedMessage: VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>>): parsedMessage is VParsedMessage<Required<VCommonParserOptions> & VParserOptions> {
 	return verifyParserOptionsIsNonLazy(parsedMessage.parserOptions);

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -1,5 +1,5 @@
 import OptionPrefix from './@types/OptionPrefix';
-import { parseMessage, VParsedMessage } from './message-parser';
+import { doParseMessage, VParsedMessage } from './message-parser';
 import OptionDef from './option-def';
 import { VLazyParsedCommand, VParsedCommand } from './vparsedcommand';
 
@@ -105,7 +105,7 @@ export class VCommandParser {
 	static parse(message: string, parserOptions?: VLazyParserOptions | VParserOptions): VLazyParsedCommand | VParsedCommand {
 		const options = mergeWithDefaultParserOptions(parserOptions);
 		
-		const parsedMessage = parseMessage(message, options);
+		const parsedMessage = doParseMessage(message, options);
 		
 		if (verifyParsedCommandType(parsedMessage)) {
 			return new VParsedCommand(message, parsedMessage);

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -17,6 +17,9 @@ export interface VCommonParserOptions {
 	 */
 	optionPrefix?: OptionPrefix;
 	
+	/**
+	 * When set to `true`, this option object will be of type `VLazyParserOptions`, otherwise, if left out or set to `false`, the type will be `VParserOptions`.
+	 */
 	lazy?: boolean;
 }
 
@@ -50,6 +53,10 @@ function mergeWithDefaultParserOptions<T extends VCommonParserOptions>(parserOpt
 	return {...defaultOptions, ...parserOptions};
 }
 
+/**
+ * Verifies if the given `parserOptions` contains values that are of not considered as lazy.
+ * @param parserOptions
+ */
 export function verifyParserOptionsIsNonLazy(parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): parserOptions is Required<VCommonParserOptions> & VParserOptions {
 	return !parserOptions.lazy && (parserOptions.optionDefinitions == undefined || Array.isArray(parserOptions.optionDefinitions));
 }

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -67,9 +67,6 @@ export class VCommandParser {
 	/**
 	 * This function parses a string and gets the component if the string is in the format `{PREFIX}{COMMAND} [{content}] [{OPTION_PREFIX}{OPTION} [{OPTION_CONTENT}] [{content}]]*` (where anything between `[]` is optional, and an `*` means multiple times).
 	 *
-	 * This function lazily parses the message, meaning only the command is processed.
-	 * To process options, you can either use the `parsedCommand.doParseOptions()` function or set the option definitions using `parsedCommand.setOptionDefinitions(definitions)`.
-	 *
 	 * @param message String that potentially contains a command.
 	 *
 	 * @param parserOptions Options used to customize the behavior of the parser.
@@ -77,9 +74,25 @@ export class VCommandParser {
 	 * @example VCommandParser.parse('!command --option "Option content"')
 	 * @example VCommandParser.parse('%%command --option "Option content"', {commandPrefix: '%%'})
 	 *
-	 * @returns `VLazyParsedCommand` instance containing the results of the parsing.
+	 * @returns `VParsedCommand` instance containing the results of the parsing.
 	 */
 	static parse(message: string, parserOptions?: VParserOptions): VParsedCommand;
+	/**
+	 * This function parses a string and gets the component if the string is in the format `{PREFIX}{COMMAND} [{content}] [{OPTION_PREFIX}{OPTION} [{OPTION_CONTENT}] [{content}]]*` (where anything between `[]` is optional, and an `*` means multiple times).
+	 *
+	 * With the specified options, the message will be lazily parsed, meaning only the command is processed.
+	 * To process options, you can either use the `parsedCommand.doParseOptions()` function or set the option definitions using `parsedCommand.setOptionDefinitions(definitions)`.
+	 *
+	 * @param message String that potentially contains a command.
+	 *
+	 * @param parserOptions Options used to customize the behavior of the parser.
+	 *
+	 * @example VCommandParser.parse('!command --option "Option content"', {lazy: true})
+	 * @example VCommandParser.parse('%%command --option "Option content"', {commandPrefix: '%%', lazy: true})
+	 * @example VCommandParser.parse('!command --option "Option content"', {optionDefinitions: () => [...]})
+	 *
+	 * @returns `VLazyParsedCommand` instance containing the results of the parsing.
+	 */
 	static parse(message: string, parserOptions?: VLazyParserOptions): VLazyParsedCommand;
 	
 	static parse(message: string, parserOptions?: VLazyParserOptions | VParserOptions): VLazyParsedCommand | VParsedCommand {

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -110,4 +110,4 @@ export class VCommandParser {
 	}
 }
 
-export default VCommandParser;
+export default VCommandParser.parse;

--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -1,11 +1,9 @@
 import OptionPrefix from './@types/OptionPrefix';
-import MessageOption from './message-option';
-import { extractOptionsFromParsedContent, ParsedMessage, parseMessage } from './message-parser';
+import { parseMessage } from './message-parser';
 import OptionDef from './option-def';
+import { VLazyParsedCommand, VParsedCommand } from './vparsedcommand';
 
-export { VCommandParser };
-
-export default class VCommandParser {
+export class VCommandParser {
 	static readonly DEFAULT_COMMAND_PREFIX = '!';
 	static readonly DEFAULT_OPTION_PREFIX = '-';
 	
@@ -61,103 +59,4 @@ export default class VCommandParser {
 	}
 }
 
-export class VParsedCommand {
-	readonly isCommand: boolean;
-	
-	readonly message: string;
-	
-	readonly command?: string;
-	readonly content?: string;
-	
-	readonly commandPrefix: string;
-	readonly optionPrefix: OptionPrefix;
-	
-	readonly optionDefinitions?: OptionDef[];
-	
-	readonly options?: MessageOption[];
-	readonly duplicatedOptions?: MessageOption[];
-	readonly fullContent?: string;
-	
-	constructor(message: string, commandPrefix = VCommandParser.DEFAULT_COMMAND_PREFIX, optionPrefix: OptionPrefix = VCommandParser.DEFAULT_OPTION_PREFIX, parsedMessage: ParsedMessage, optionDefinitions?: OptionDef[]) {
-		this.message = message;
-		this.commandPrefix = commandPrefix;
-		this.optionPrefix = optionPrefix;
-		this.optionDefinitions = optionDefinitions;
-		
-		({
-			isCommand: this.isCommand,
-			command: this.command,
-			content: this.content,
-			options: this.options,
-			duplicatedOptions: this.duplicatedOptions,
-			fullContent: this.fullContent
-		} = parsedMessage);
-	}
-	
-	/**
-	 * Retrieves an option from the list of options.
-	 *
-	 * @param call The name of the option / one of its aliases to use for the search method.
-	 *
-	 * If the option has a definition, this definition will be used to try and match the given call with the defined calls, otherwise, it will check if the option name matches the given call.
-	 *
-	 * If no option has such call, `undefined` is returned.
-	 */
-	getOption(call: string): MessageOption | undefined;
-	
-	/**
-	 * Retrieves an option from the list of options.
-	 *
-	 * @param position The position that the option is in.
-	 *
-	 * If no option is in that position, `undefined` is returned.
-	 */
-	getOption(position: number): MessageOption | undefined;
-	
-	getOption(search: string | number): MessageOption | undefined {
-		return this.options?.find(option => {
-			if (typeof search == 'string') {
-				return option.definition?.calls.includes(search) || option.name == search;
-			} else {
-				return option.position == search;
-			}
-		});
-	}
-	
-	/**
-	 * Sets the option definitions, even if the message has already been parsed, and updates the properties to reflect the given definitions.
-	 *
-	 * @param optionDefinitions Array of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
-	 */
-	setOptionDefinitions(optionDefinitions: OptionDef[]): void {
-		this.doExtractOptions(optionDefinitions);
-	}
-	
-	protected doExtractOptions(optionDefinitions?: OptionDef[]): void {
-		// If there was already no content, there will surely not be any options in it
-		if (this.fullContent) {
-			const parsedOptions = extractOptionsFromParsedContent(this.fullContent, this.optionPrefix, optionDefinitions);
-			
-			({
-				content: (this.content as string | undefined),
-				options: (this.options as MessageOption[] | undefined),
-				duplicatedOptions: (this.duplicatedOptions as MessageOption[] | undefined),
-			} = parsedOptions);
-		}
-	}
-}
-
-export class VLazyParsedCommand extends VParsedCommand {
-	constructor(message: string, commandPrefix = VCommandParser.DEFAULT_COMMAND_PREFIX, optionPrefix: OptionPrefix = VCommandParser.DEFAULT_OPTION_PREFIX, parsedMessage: ParsedMessage, optionDefinitions?: OptionDef[]) {
-		super(message, commandPrefix, optionPrefix, parsedMessage, optionDefinitions);
-	}
-	
-	/**
-	 * This function parses the full message to extract the options from the content of the message.
-	 *
-	 * This has no value if you called the `setOptionDefinitions` function before.
-	 */
-	doParseOptions(): void {
-		this.doExtractOptions();
-	}
-}
+export default VCommandParser;

--- a/src/vparsedcommand.ts
+++ b/src/vparsedcommand.ts
@@ -2,7 +2,7 @@ import OptionPrefix from './@types/OptionPrefix';
 import MessageOption from './message-option';
 import { extractOptionsFromParsedContent, VParsedMessage } from './message-parser';
 import OptionDef from './option-def';
-import { RequiredParserOptions, VLazyParserOptions, VParserOptions } from './vcommandparser';
+import { RequiredParserOptions, verifyParserOptionsIsNonLazy, VLazyParserOptions, VParserOptions } from './vcommandparser';
 
 export class VCommonParsedCommand {
 	readonly isCommand: boolean;
@@ -37,7 +37,7 @@ export class VCommonParsedCommand {
 			},
 		} = parsedMessage);
 		
-		if (Array.isArray(parsedMessage.parserOptions.optionDefinitions)) {
+		if (verifyParserOptionsIsNonLazy(parsedMessage.parserOptions)) {
 			this.optionDefinitions = parsedMessage.parserOptions.optionDefinitions;
 		}
 	}

--- a/src/vparsedcommand.ts
+++ b/src/vparsedcommand.ts
@@ -1,0 +1,108 @@
+import OptionPrefix from './@types/OptionPrefix';
+import MessageOption from './message-option';
+import { extractOptionsFromParsedContent, ParsedMessage } from './message-parser';
+import OptionDef from './option-def';
+import VCommandParser from './vcommandparser';
+
+export class VParsedCommand {
+	readonly isCommand: boolean;
+	
+	readonly message: string;
+	
+	readonly command?: string;
+	readonly content?: string;
+	
+	readonly commandPrefix: string;
+	readonly optionPrefix: OptionPrefix;
+	
+	readonly optionDefinitions?: OptionDef[];
+	
+	readonly options?: MessageOption[];
+	readonly duplicatedOptions?: MessageOption[];
+	readonly fullContent?: string;
+	
+	constructor(message: string, commandPrefix = VCommandParser.DEFAULT_COMMAND_PREFIX, optionPrefix: OptionPrefix = VCommandParser.DEFAULT_OPTION_PREFIX, parsedMessage: ParsedMessage, optionDefinitions?: OptionDef[]) {
+		this.message = message;
+		this.commandPrefix = commandPrefix;
+		this.optionPrefix = optionPrefix;
+		this.optionDefinitions = optionDefinitions;
+		
+		({
+			isCommand: this.isCommand,
+			command: this.command,
+			content: this.content,
+			options: this.options,
+			duplicatedOptions: this.duplicatedOptions,
+			fullContent: this.fullContent
+		} = parsedMessage);
+	}
+	
+	/**
+	 * Retrieves an option from the list of options.
+	 *
+	 * @param call The name of the option / one of its aliases to use for the search method.
+	 *
+	 * If the option has a definition, this definition will be used to try and match the given call with the defined calls, otherwise, it will check if the option name matches the given call.
+	 *
+	 * If no option has such call, `undefined` is returned.
+	 */
+	getOption(call: string): MessageOption | undefined;
+	
+	/**
+	 * Retrieves an option from the list of options.
+	 *
+	 * @param position The position that the option is in.
+	 *
+	 * If no option is in that position, `undefined` is returned.
+	 */
+	getOption(position: number): MessageOption | undefined;
+	
+	getOption(search: string | number): MessageOption | undefined {
+		return this.options?.find(option => {
+			if (typeof search == 'string') {
+				return option.definition?.calls.includes(search) || option.name == search;
+			} else {
+				return option.position == search;
+			}
+		});
+	}
+	
+	/**
+	 * Sets the option definitions, even if the message has already been parsed, and updates the properties to reflect the given definitions.
+	 *
+	 * @param optionDefinitions Array of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
+	 */
+	setOptionDefinitions(optionDefinitions: OptionDef[]): void {
+		this.doExtractOptions(optionDefinitions);
+	}
+	
+	protected doExtractOptions(optionDefinitions?: OptionDef[]): void {
+		// If there was already no content, there will surely not be any options in it
+		if (this.fullContent) {
+			const parsedOptions = extractOptionsFromParsedContent(this.fullContent, this.optionPrefix, optionDefinitions);
+			
+			({
+				content: (this.content as string | undefined),
+				options: (this.options as MessageOption[] | undefined),
+				duplicatedOptions: (this.duplicatedOptions as MessageOption[] | undefined),
+			} = parsedOptions);
+		}
+	}
+}
+
+export class VLazyParsedCommand extends VParsedCommand {
+	constructor(message: string, commandPrefix = VCommandParser.DEFAULT_COMMAND_PREFIX, optionPrefix: OptionPrefix = VCommandParser.DEFAULT_OPTION_PREFIX, parsedMessage: ParsedMessage, optionDefinitions?: OptionDef[]) {
+		super(message, commandPrefix, optionPrefix, parsedMessage, optionDefinitions);
+	}
+	
+	/**
+	 * This function parses the full message to extract the options from the content of the message.
+	 *
+	 * This has no value if you called the `setOptionDefinitions` function before.
+	 */
+	doParseOptions(): void {
+		this.doExtractOptions();
+	}
+}
+
+export default VLazyParsedCommand;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -11,7 +11,7 @@ describe('Testing value types', () => {
 	});
 	
 	it('parsed object should be of type VLazyParsedCommand', () => {
-		const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+		const parsed = VCommandParser.parse('!mycommand', {lazy: true});
 		
 		expect(parsed instanceof VLazyParsedCommand).toBeTruthy();
 	});
@@ -172,39 +172,39 @@ describe('Non-lazy parsing', () => {
 describe('Lazy parsing', () => {
 	describe('Basic Message Parsing', () => {
 		it('should return correct command', () => {
-			const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand', {lazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 		});
 		
 		it('should return correct command and content', () => {
-			const parsed = VCommandParser.parse('!mycommand my content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand my content', {lazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('my content');
 		});
 		
 		it('should return correct command with custom prefix', () => {
-			const parsed = VCommandParser.parse('\\mycommand', {commandPrefix: '\\', isLazy: true});
+			const parsed = VCommandParser.parse('\\mycommand', {commandPrefix: '\\', lazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 		});
 		
 		it('should return correct command and content with custom prefix', () => {
-			const parsed = VCommandParser.parse('\\mycommand my content', {commandPrefix: '\\', isLazy: true});
+			const parsed = VCommandParser.parse('\\mycommand my content', {commandPrefix: '\\', lazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('my content');
 		});
 		
 		it('should parse message and define isCommand to true', () => {
-			const parsed = VCommandParser.parse('!mycommand my content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand my content', {lazy: true});
 			
 			expect(parsed.isCommand).toBeTruthy();
 		});
 		
 		it('should return proper content and options', () => {
-			const parsed = VCommandParser.parse('!mycommand content --option option_content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand content --option option_content', {lazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('content --option option_content');
@@ -227,7 +227,7 @@ describe('Lazy parsing', () => {
 	describe('Testing VLazyParsedCommand basic functions', () => {
 		describe('getOption function with string', () => {
 			it('should return undefined when no option', () => {
-				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -237,7 +237,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return undefined when option not in request', () => {
-				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -247,7 +247,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct name', () => {
-				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -258,7 +258,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct name despite multiple options', () => {
-				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -271,7 +271,7 @@ describe('Lazy parsing', () => {
 		
 		describe('getOption function with number', () => {
 			it('should return undefined when no option', () => {
-				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -281,7 +281,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return undefined when no option with position', () => {
-				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -291,7 +291,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct position', () => {
-				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -302,7 +302,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct position despite multiple options', () => {
-				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {lazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -316,21 +316,21 @@ describe('Lazy parsing', () => {
 	
 	describe('Non-commands parsing behaviors', () => {
 		it('should parse message and define isCommand to false', () => {
-			const parsed = VCommandParser.parse('this is a message', {isLazy: true});
+			const parsed = VCommandParser.parse('this is a message', {lazy: true});
 			
 			expect(parsed.isCommand).toBeFalsy();
 			expect(parsed.command).toBeUndefined();
 		});
 		
 		it('should parse message and not parse options', () => {
-			const parsed = VCommandParser.parse('this is --a message', {isLazy: true});
+			const parsed = VCommandParser.parse('this is --a message', {lazy: true});
 			
 			expect(parsed.options).toBeUndefined();
 			expect(parsed.content).toBe('this is --a message');
 		});
 		
 		it('should parse message and not parse as a command if there is a space between prefix and command', () => {
-			const parsed = VCommandParser.parse('! not a command', {isLazy: true});
+			const parsed = VCommandParser.parse('! not a command', {lazy: true});
 			
 			expect(parsed.isCommand).toBeFalsy();
 			expect(parsed.command).toBeUndefined();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,6 +1,27 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 import VCommandParser from '../src/vcommandparser';
+import VLazyParsedCommand, { VParsedCommand } from '../src/vparsedcommand';
+
+describe('Testing value types', () => {
+	it('parsed object should be of type VParsedCommand', () => {
+		const parsed = VCommandParser.parse('!mycommand');
+		
+		expect(parsed instanceof VParsedCommand).toBeTruthy();
+	});
+	
+	it('parsed object should be of type VLazyParsedCommand', () => {
+		const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+		
+		expect(parsed instanceof VLazyParsedCommand).toBeTruthy();
+	});
+	
+	it('parsed object should be of type VLazyParsedCommand when custom optionDefs', () => {
+		const parsed = VCommandParser.parse('!mycommand', {optionDefinitions: () => []});
+		
+		expect(parsed instanceof VLazyParsedCommand).toBeTruthy();
+	});
+});
 
 describe('Non-lazy parsing', () => {
 	describe('Basic Message Parsing', () => {
@@ -18,13 +39,13 @@ describe('Non-lazy parsing', () => {
 		});
 		
 		it('should return correct command with custom prefix', () => {
-			const parsed = VCommandParser.parse('\\mycommand', '\\');
+			const parsed = VCommandParser.parse('\\mycommand', {commandPrefix: '\\'});
 			
 			expect(parsed.command).toBe('mycommand');
 		});
 		
 		it('should return correct command and content with custom prefix', () => {
-			const parsed = VCommandParser.parse('\\mycommand my content', '\\');
+			const parsed = VCommandParser.parse('\\mycommand my content', {commandPrefix: '\\'});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('my content');
@@ -34,6 +55,18 @@ describe('Non-lazy parsing', () => {
 			const parsed = VCommandParser.parse('!mycommand my content');
 			
 			expect(parsed.isCommand).toBeTruthy();
+		});
+		
+		it('should return proper content and options', () => {
+			const parsed = VCommandParser.parse('!mycommand content --option option_content');
+			
+			expect(parsed.command).toBe('mycommand');
+			expect(parsed.content).toBe('content');
+			
+			const option = parsed.getOption('option');
+			
+			expect(option).toBeDefined();
+			expect(option!.content).toBe('option_content');
 		});
 	});
 	
@@ -139,42 +172,62 @@ describe('Non-lazy parsing', () => {
 describe('Lazy parsing', () => {
 	describe('Basic Message Parsing', () => {
 		it('should return correct command', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand');
+			const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 		});
 		
 		it('should return correct command and content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand my content');
+			const parsed = VCommandParser.parse('!mycommand my content', {isLazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('my content');
 		});
 		
 		it('should return correct command with custom prefix', () => {
-			const parsed = VCommandParser.parseLazy('\\mycommand', '\\');
+			const parsed = VCommandParser.parse('\\mycommand', {commandPrefix: '\\', isLazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 		});
 		
 		it('should return correct command and content with custom prefix', () => {
-			const parsed = VCommandParser.parseLazy('\\mycommand my content', '\\');
+			const parsed = VCommandParser.parse('\\mycommand my content', {commandPrefix: '\\', isLazy: true});
 			
 			expect(parsed.command).toBe('mycommand');
 			expect(parsed.content).toBe('my content');
 		});
 		
 		it('should parse message and define isCommand to true', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand my content');
+			const parsed = VCommandParser.parse('!mycommand my content', {isLazy: true});
 			
 			expect(parsed.isCommand).toBeTruthy();
+		});
+		
+		it('should return proper content and options', () => {
+			const parsed = VCommandParser.parse('!mycommand content --option option_content', {isLazy: true});
+			
+			expect(parsed.command).toBe('mycommand');
+			expect(parsed.content).toBe('content --option option_content');
+			
+			const option1 = parsed.getOption('option');
+			
+			expect(option1).toBeUndefined();
+			
+			parsed.doParseOptions();
+			
+			expect(parsed.content).toBe('content');
+			
+			const option2 = parsed.getOption('option');
+			
+			expect(option2).toBeDefined();
+			expect(option2!.content).toBe('option_content');
 		});
 	});
 	
 	describe('Testing VLazyParsedCommand basic functions', () => {
 		describe('getOption function with string', () => {
 			it('should return undefined when no option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand');
+				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -184,7 +237,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return undefined when option not in request', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option');
+				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -194,7 +247,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct name', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option');
+				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -205,7 +258,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct name despite multiple options', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option1 --option2');
+				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -218,7 +271,7 @@ describe('Lazy parsing', () => {
 		
 		describe('getOption function with number', () => {
 			it('should return undefined when no option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand');
+				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -228,7 +281,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return undefined when no option with position', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option');
+				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -238,7 +291,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct position', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option');
+				const parsed = VCommandParser.parse('!mycommand --option', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -249,7 +302,7 @@ describe('Lazy parsing', () => {
 			});
 			
 			it('should return option with correct position despite multiple options', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --option1 --option2');
+				const parsed = VCommandParser.parse('!mycommand --option1 --option2', {isLazy: true});
 				
 				parsed.doParseOptions();
 				
@@ -263,21 +316,21 @@ describe('Lazy parsing', () => {
 	
 	describe('Non-commands parsing behaviors', () => {
 		it('should parse message and define isCommand to false', () => {
-			const parsed = VCommandParser.parseLazy('this is a message');
+			const parsed = VCommandParser.parse('this is a message', {isLazy: true});
 			
 			expect(parsed.isCommand).toBeFalsy();
 			expect(parsed.command).toBeUndefined();
 		});
 		
 		it('should parse message and not parse options', () => {
-			const parsed = VCommandParser.parseLazy('this is --a message');
+			const parsed = VCommandParser.parse('this is --a message', {isLazy: true});
 			
 			expect(parsed.options).toBeUndefined();
 			expect(parsed.content).toBe('this is --a message');
 		});
 		
 		it('should parse message and not parse as a command if there is a space between prefix and command', () => {
-			const parsed = VCommandParser.parseLazy('! not a command');
+			const parsed = VCommandParser.parse('! not a command', {isLazy: true});
 			
 			expect(parsed.isCommand).toBeFalsy();
 			expect(parsed.command).toBeUndefined();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import VCommandParser from '../src/vcommandparser';
+import * as testParseMessage from '../src/index';
+import { VCommandParser } from '../src/vcommandparser';
 import VLazyParsedCommand, { VParsedCommand } from '../src/vparsedcommand';
+
+describe('Checking exported functions', () => {
+	it('should provide parseMessage as VCommandParser.parse', () => {
+		expect(testParseMessage.parseMessage).toBe(testParseMessage.VCommandParser.parse);
+	});
+});
 
 describe('Testing value types', () => {
 	it('parsed object should be of type VParsedCommand', () => {

--- a/tests/options-custom-prefix.test.ts
+++ b/tests/options-custom-prefix.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import VCommandParser from '../src/vcommandparser';
+import { VCommandParser } from '../src/vcommandparser';
 
 describe('custom option prefix', () => {
 	describe('Messages with basic options', () => {

--- a/tests/options-custom-prefix.test.ts
+++ b/tests/options-custom-prefix.test.ts
@@ -5,7 +5,7 @@ import VCommandParser from '../src/vcommandparser';
 describe('custom option prefix', () => {
 	describe('Messages with basic options', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -17,7 +17,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -29,7 +29,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -42,7 +42,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~short', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~short', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -58,7 +58,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -71,7 +71,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 ~~long3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 ~~long3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -85,7 +85,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~h', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~h', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -98,7 +98,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~h ~o', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~h ~o', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -112,7 +112,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh ~or', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh ~or', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -129,7 +129,7 @@ describe('custom option prefix', () => {
 	
 	describe('Messages with basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -141,7 +141,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -153,7 +153,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -166,7 +166,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~short content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~short content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -182,7 +182,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -195,7 +195,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2 ~~long3 content3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2 ~~long3 content3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -209,7 +209,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 content ~~long3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 content ~~long3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -223,7 +223,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -236,7 +236,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2 ~o content3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2 ~o content3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -250,7 +250,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~h content ~o', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~h content ~o', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -264,7 +264,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh content1 ~or content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh content1 ~or content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -281,7 +281,7 @@ describe('custom option prefix', () => {
 	
 	describe('Messages with content and basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand mycontent ~~long content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand mycontent ~~long content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('mycontent');
 			
@@ -293,7 +293,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content', () => {
-			const parsed = VCommandParser.parse('!mycommand my content ~~long content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand my content ~~long content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('my content');
 			
@@ -305,7 +305,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one long option content after', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long content mycontent', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long content mycontent', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('mycontent');
 			expect(parsed.options).toBeDefined();
@@ -316,7 +316,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content after', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long content my content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long content my content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('my content');
 			
@@ -328,7 +328,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand mcontent ~s content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand mcontent ~s content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('mcontent');
 			
@@ -340,7 +340,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content', () => {
-			const parsed = VCommandParser.parse('!mycommand my content ~s content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand my content ~s content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('my content');
 			
@@ -352,7 +352,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option after', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content mcontent', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content mcontent', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('mcontent');
 			
@@ -364,7 +364,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content after', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content my content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content my content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('my content');
 			
@@ -376,7 +376,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -389,7 +389,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand ~short content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~short content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -405,7 +405,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -418,7 +418,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2 ~~long3 content3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 content1 ~~long2 content2 ~~long3 content3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -432,7 +432,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 content ~~long3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long1 ~~long2 content ~~long3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -446,7 +446,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -459,7 +459,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2 ~o content3', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s content1 ~h content2 ~o content3', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -473,7 +473,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~h content ~o', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~h content ~o', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -487,7 +487,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand ~sh content1 ~or content2', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~sh content1 ~or content2', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBeUndefined();
 			
@@ -504,19 +504,19 @@ describe('custom option prefix', () => {
 	
 	describe('Messages with option stopper', () => {
 		it('should contain content only', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~ content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~ content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('content');
 		});
 		
 		it('should contain both content only', () => {
-			const parsed = VCommandParser.parse('!mycommand my ~~ content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand my ~~ content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('my content');
 		});
 		
 		it('should contain one long option and content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long ~~ content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long ~~ content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('content');
 			
@@ -528,7 +528,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one long option and option like content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~~long ~~ ~~content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~~long ~~ ~~content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('~~content');
 			
@@ -540,7 +540,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option and content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~~ content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~~ content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('content');
 			
@@ -552,7 +552,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain one short option and option like content', () => {
-			const parsed = VCommandParser.parse('!mycommand ~s ~~ ~~content', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand ~s ~~ ~~content', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('~~content');
 			
@@ -564,7 +564,7 @@ describe('custom option prefix', () => {
 		});
 		
 		it('should contain stopper as content', () => {
-			const parsed = VCommandParser.parse('!mycommand "~~"', undefined, '~');
+			const parsed = VCommandParser.parse('!mycommand "~~"', {optionPrefix: '~'});
 			
 			expect(parsed.content).toBe('~~');
 		});

--- a/tests/options-lazy.test.ts
+++ b/tests/options-lazy.test.ts
@@ -5,7 +5,7 @@ import VCommandParser from '../src/vcommandparser';
 describe('default option prefix', () => {
 	describe('Messages with basic options', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -19,7 +19,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -33,7 +33,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -48,7 +48,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -short', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -short', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -66,7 +66,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 --long2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -81,7 +81,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 --long2 --long3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 --long3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -97,7 +97,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -h', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -h', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -112,7 +112,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -h -o', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -h -o', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -128,7 +128,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh -or', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh -or', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -147,7 +147,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -161,7 +161,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -175,7 +175,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -190,7 +190,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -short content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -short content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -208,7 +208,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -223,7 +223,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -239,7 +239,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -255,7 +255,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -270,7 +270,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -286,7 +286,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -302,7 +302,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -321,7 +321,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with content and basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parse('!mycommand mycontent --long content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand mycontent --long content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -335,7 +335,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content', () => {
-			const parsed = VCommandParser.parse('!mycommand my content --long content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand my content --long content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -349,7 +349,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option content after', () => {
-			const parsed = VCommandParser.parse('!mycommand --long content mycontent', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long content mycontent', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -363,7 +363,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content after', () => {
-			const parsed = VCommandParser.parse('!mycommand --long content my content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long content my content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -377,7 +377,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parse('!mycommand mcontent -s content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand mcontent -s content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -391,7 +391,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content', () => {
-			const parsed = VCommandParser.parse('!mycommand my content -s content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand my content -s content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -405,7 +405,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option after', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content mcontent', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content mcontent', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -419,7 +419,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content after', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content my content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content my content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -433,7 +433,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -448,7 +448,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parse('!mycommand -short content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -short content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -466,7 +466,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -481,7 +481,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -497,7 +497,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -513,7 +513,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -528,7 +528,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -544,7 +544,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -560,7 +560,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -579,7 +579,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with option stopper', () => {
 		it('should contain content only', () => {
-			const parsed = VCommandParser.parse('!mycommand -- content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -- content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -587,7 +587,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain both content only', () => {
-			const parsed = VCommandParser.parse('!mycommand my -- content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand my -- content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -595,7 +595,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and content', () => {
-			const parsed = VCommandParser.parse('!mycommand --long -- content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long -- content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -609,7 +609,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and option like content', () => {
-			const parsed = VCommandParser.parse('!mycommand --long -- --content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long -- --content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -623,7 +623,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and content', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -- content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -- content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -637,7 +637,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and option like content', () => {
-			const parsed = VCommandParser.parse('!mycommand -s -- --content', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s -- --content', {lazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -651,7 +651,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain stopper as content', () => {
-			const parsed = VCommandParser.parse('!mycommand "--"', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand "--"', {lazy: true});
 			
 			parsed.doParseOptions();
 			

--- a/tests/options-lazy.test.ts
+++ b/tests/options-lazy.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import VCommandParser from '../src/vcommandparser';
+import { VCommandParser } from '../src/vcommandparser';
 
 describe('default option prefix', () => {
 	describe('Messages with basic options', () => {

--- a/tests/options-lazy.test.ts
+++ b/tests/options-lazy.test.ts
@@ -5,7 +5,7 @@ import VCommandParser from '../src/vcommandparser';
 describe('default option prefix', () => {
 	describe('Messages with basic options', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long');
+			const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -19,7 +19,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s');
+			const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -33,7 +33,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh');
+			const parsed = VCommandParser.parse('!mycommand -sh', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -48,7 +48,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -short');
+			const parsed = VCommandParser.parse('!mycommand -short', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -66,7 +66,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 --long2');
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -81,7 +81,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 --long2 --long3');
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 --long3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -97,7 +97,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -h');
+			const parsed = VCommandParser.parse('!mycommand -s -h', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -112,7 +112,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -h -o');
+			const parsed = VCommandParser.parse('!mycommand -s -h -o', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -128,7 +128,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh -or');
+			const parsed = VCommandParser.parse('!mycommand -sh -or', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -147,7 +147,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long content');
+			const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -161,7 +161,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content');
+			const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -175,7 +175,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh content');
+			const parsed = VCommandParser.parse('!mycommand -sh content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -190,7 +190,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -short content');
+			const parsed = VCommandParser.parse('!mycommand -short content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -208,7 +208,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 content1 --long2 content2');
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -223,7 +223,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 content1 --long2 content2 --long3 content3');
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -239,7 +239,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 --long2 content --long3');
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -255,7 +255,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content1 -h content2');
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -270,7 +270,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content1 -h content2 -o content3');
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -286,7 +286,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -h content -o');
+			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -302,7 +302,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh content1 -or content2');
+			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -321,7 +321,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with content and basic options and content', () => {
 		it('should contain one long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand mycontent --long content');
+			const parsed = VCommandParser.parse('!mycommand mycontent --long content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -335,7 +335,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand my content --long content');
+			const parsed = VCommandParser.parse('!mycommand my content --long content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -349,7 +349,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option content after', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long content mycontent');
+			const parsed = VCommandParser.parse('!mycommand --long content mycontent', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -363,7 +363,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and spaced content after', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long content my content');
+			const parsed = VCommandParser.parse('!mycommand --long content my content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -377,7 +377,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand mcontent -s content');
+			const parsed = VCommandParser.parse('!mycommand mcontent -s content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -391,7 +391,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand my content -s content');
+			const parsed = VCommandParser.parse('!mycommand my content -s content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -405,7 +405,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option after', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content mcontent');
+			const parsed = VCommandParser.parse('!mycommand -s content mcontent', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -419,7 +419,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and spaced content after', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content my content');
+			const parsed = VCommandParser.parse('!mycommand -s content my content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -433,7 +433,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh content');
+			const parsed = VCommandParser.parse('!mycommand -sh content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -448,7 +448,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain five short option stickied', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -short content');
+			const parsed = VCommandParser.parse('!mycommand -short content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -466,7 +466,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 content1 --long2 content2');
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -481,7 +481,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 content1 --long2 content2 --long3 content3');
+			const parsed = VCommandParser.parse('!mycommand --long1 content1 --long2 content2 --long3 content3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -497,7 +497,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three long option only one content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long1 --long2 content --long3');
+			const parsed = VCommandParser.parse('!mycommand --long1 --long2 content --long3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -513,7 +513,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain two short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content1 -h content2');
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -528,7 +528,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s content1 -h content2 -o content3');
+			const parsed = VCommandParser.parse('!mycommand -s content1 -h content2 -o content3', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -544,7 +544,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain three short option only one content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -h content -o');
+			const parsed = VCommandParser.parse('!mycommand -s -h content -o', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -560,7 +560,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain four short option, 2 stickied groups', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -sh content1 -or content2');
+			const parsed = VCommandParser.parse('!mycommand -sh content1 -or content2', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -579,7 +579,7 @@ describe('default option prefix', () => {
 	
 	describe('Messages with option stopper', () => {
 		it('should contain content only', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -- content');
+			const parsed = VCommandParser.parse('!mycommand -- content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -587,7 +587,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain both content only', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand my -- content');
+			const parsed = VCommandParser.parse('!mycommand my -- content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -595,7 +595,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long -- content');
+			const parsed = VCommandParser.parse('!mycommand --long -- content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -609,7 +609,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one long option and option like content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long -- --content');
+			const parsed = VCommandParser.parse('!mycommand --long -- --content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -623,7 +623,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -- content');
+			const parsed = VCommandParser.parse('!mycommand -s -- content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -637,7 +637,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain one short option and option like content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s -- --content');
+			const parsed = VCommandParser.parse('!mycommand -s -- --content', {isLazy: true});
 			
 			parsed.doParseOptions();
 			
@@ -651,7 +651,7 @@ describe('default option prefix', () => {
 		});
 		
 		it('should contain stopper as content', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand "--"');
+			const parsed = VCommandParser.parse('!mycommand "--"', {isLazy: true});
 			
 			parsed.doParseOptions();
 			

--- a/tests/options-with-defs.test.ts
+++ b/tests/options-with-defs.test.ts
@@ -17,7 +17,7 @@ describe('default option prefix with definitions', () => {
 	describe('Messages with basic options', () => {
 		describe('options do accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parse('!mycommand --long', undefined, undefined, optionDefinitions);
+				const parsed = VCommandParser.parse('!mycommand --long', {optionDefinitions: optionDefinitions});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -31,7 +31,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parse('!mycommand -s', undefined, undefined, optionDefinitions);
+				const parsed = VCommandParser.parse('!mycommand -s', {optionDefinitions: optionDefinitions});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -45,7 +45,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand --long content', undefined, undefined, optionDefinitions);
+				const parsed = VCommandParser.parse('!mycommand --long content', {optionDefinitions: optionDefinitions});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -59,7 +59,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand -s content', undefined, undefined, optionDefinitions);
+				const parsed = VCommandParser.parse('!mycommand -s content', {optionDefinitions: optionDefinitions});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -75,7 +75,7 @@ describe('default option prefix with definitions', () => {
 		
 		describe('options do not accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parse('!mycommand --long', undefined, undefined, optionDefinitionsNoContent);
+				const parsed = VCommandParser.parse('!mycommand --long', {optionDefinitions: optionDefinitionsNoContent});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -89,7 +89,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parse('!mycommand -s', undefined, undefined, optionDefinitionsNoContent);
+				const parsed = VCommandParser.parse('!mycommand -s', {optionDefinitions: optionDefinitionsNoContent});
 				
 				expect(parsed.options).toBeDefined();
 				if (parsed.options) {
@@ -103,7 +103,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand --long content', undefined, undefined, optionDefinitionsNoContent);
+				const parsed = VCommandParser.parse('!mycommand --long content', {optionDefinitions: optionDefinitionsNoContent});
 				
 				expect(parsed.content).toBe('content');
 				
@@ -119,7 +119,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand -s content', undefined, undefined, optionDefinitionsNoContent);
+				const parsed = VCommandParser.parse('!mycommand -s content', {optionDefinitions: optionDefinitionsNoContent});
 				
 				expect(parsed.content).toBe('content');
 				
@@ -143,7 +143,7 @@ describe('default option prefix with definitions', () => {
 	
 	describe('retrieving options from command parser', () => {
 		it('should retrieve long option by short call', () => {
-			const parsed = VCommandParser.parse('!mycommand --long', undefined, undefined, optionDefinitionsMultipleCalls);
+			const parsed = VCommandParser.parse('!mycommand --long', {optionDefinitions: optionDefinitionsMultipleCalls});
 			
 			const option = parsed.getOption('l');
 			
@@ -152,7 +152,7 @@ describe('default option prefix with definitions', () => {
 		});
 		
 		it('should retrieve short option by long call', () => {
-			const parsed = VCommandParser.parse('!mycommand -s', undefined, undefined, optionDefinitionsMultipleCalls);
+			const parsed = VCommandParser.parse('!mycommand -s', {optionDefinitions: optionDefinitionsMultipleCalls});
 			
 			const option = parsed.getOption('short');
 			

--- a/tests/options-with-defs.test.ts
+++ b/tests/options-with-defs.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 import OptionDef from '../src/option-def';
-import VCommandParser from '../src/vcommandparser';
+import { VCommandParser } from '../src/vcommandparser';
 
 const optionDefinitions = [
 	new OptionDef('long', {description: 'This is my long description', acceptsContent: true}),

--- a/tests/options-with-lazy-defs.test.ts
+++ b/tests/options-with-lazy-defs.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 import OptionDef from '../src/option-def';
-import VCommandParser from '../src/vcommandparser';
+import { VCommandParser } from '../src/vcommandparser';
 
 const optionDefinitions = [
 	new OptionDef('long', {description: 'This is my long description', acceptsContent: true}),

--- a/tests/options-with-lazy-defs.test.ts
+++ b/tests/options-with-lazy-defs.test.ts
@@ -17,7 +17,7 @@ describe('default option prefix with definitions', () => {
 	describe('Messages with basic options', () => {
 		describe('no content', () => {
 			it('should not have options', () => {
-				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -27,7 +27,7 @@ describe('default option prefix with definitions', () => {
 		
 		describe('options do accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --long', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -43,7 +43,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand -s', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -59,7 +59,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --long content', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -75,7 +75,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand -s content', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -93,7 +93,7 @@ describe('default option prefix with definitions', () => {
 		
 		describe('options do not accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --long', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -109,7 +109,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand -s', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -125,7 +125,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand --long content', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -143,7 +143,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
+				const parsed = VCommandParser.parse('!mycommand -s content', {lazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -169,7 +169,7 @@ describe('default option prefix with definitions', () => {
 	
 	describe('retrieving options from command parser', () => {
 		it('should retrieve long option by short call', () => {
-			const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand --long', {lazy: true});
 			
 			parsed.setOptionDefinitions(optionDefinitionsMultipleCalls);
 			
@@ -180,7 +180,7 @@ describe('default option prefix with definitions', () => {
 		});
 		
 		it('should retrieve short option by long call', () => {
-			const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
+			const parsed = VCommandParser.parse('!mycommand -s', {lazy: true});
 			
 			parsed.setOptionDefinitions(optionDefinitionsMultipleCalls);
 			

--- a/tests/options-with-lazy-defs.test.ts
+++ b/tests/options-with-lazy-defs.test.ts
@@ -17,7 +17,7 @@ describe('default option prefix with definitions', () => {
 	describe('Messages with basic options', () => {
 		describe('no content', () => {
 			it('should not have options', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand');
+				const parsed = VCommandParser.parse('!mycommand', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -27,7 +27,7 @@ describe('default option prefix with definitions', () => {
 		
 		describe('options do accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --long');
+				const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -43,7 +43,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand -s');
+				const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -59,7 +59,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --long content');
+				const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -75,7 +75,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand -s content');
+				const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitions);
 				
@@ -93,7 +93,7 @@ describe('default option prefix with definitions', () => {
 		
 		describe('options do not accept', () => {
 			it('should contain one defined long option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --long');
+				const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -109,7 +109,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand -s');
+				const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -125,7 +125,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined long option with content', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand --long content');
+				const parsed = VCommandParser.parse('!mycommand --long content', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -143,7 +143,7 @@ describe('default option prefix with definitions', () => {
 			});
 			
 			it('should contain one defined short option with content', () => {
-				const parsed = VCommandParser.parseLazy('!mycommand -s content');
+				const parsed = VCommandParser.parse('!mycommand -s content', {isLazy: true});
 				
 				parsed.setOptionDefinitions(optionDefinitionsNoContent);
 				
@@ -169,7 +169,7 @@ describe('default option prefix with definitions', () => {
 	
 	describe('retrieving options from command parser', () => {
 		it('should retrieve long option by short call', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand --long');
+			const parsed = VCommandParser.parse('!mycommand --long', {isLazy: true});
 			
 			parsed.setOptionDefinitions(optionDefinitionsMultipleCalls);
 			
@@ -180,7 +180,7 @@ describe('default option prefix with definitions', () => {
 		});
 		
 		it('should retrieve short option by long call', () => {
-			const parsed = VCommandParser.parseLazy('!mycommand -s');
+			const parsed = VCommandParser.parse('!mycommand -s', {isLazy: true});
 			
 			parsed.setOptionDefinitions(optionDefinitionsMultipleCalls);
 			

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
-import VCommandParser from '../src/vcommandparser';
+import { VCommandParser } from '../src/vcommandparser';
 
 describe('default option prefix', () => {
 	describe('Messages with basic options', () => {


### PR DESCRIPTION
This PR changes how the parser works by implementing the Option Object pattern, which allows the `parse` function to have a parameter which contains the customization required for the parsing of the command / message.

Essentially, you don't send the `commandPrefix` or the `optionPrefix` in parameters anymore, but rather through an object that may or may not be present. This allows for a easy time changing only the option prefix if desired.

This change also affect lazy parsing : instead of having another function dedicated for lazy loading, you now simply pass the `lazy` property (set to `true`) and the `parse` method will return the appropriate type and containing functions.

The default exports have also been changed, now that there is only one unique parse function. This parse function is the one being exported by default in the index file, meaning that to use the old `VCommandParser.parse` behavior, you need to import it using `import { VCommandParser } from 'vcommand-parser'` (the brackets are now required), otherwise the `parseMessage` method alias will be used instead.

## TODO

- [x] Update README
- [x] Update JSDoc
- [x] Add new JSDoc if necessary
- [x] Update tests