### PR TITLE
Tweak options of lazy parser to allow for direct array

### DIFF
--- a/src/vcommandparser.ts
+++ b/src/vcommandparser.ts
@@ -27,9 +27,11 @@ export interface VLazyParserOptions extends VCommonParserOptions {
 	lazy?: true;
 	
 	/**
-	 * Function to return the array of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
+	 * Array (or function to return the array) of option definitions that tells the parser how to map options and tweak some behaviors, such as if the option accepts content.
+	 *
+	 * Remember to use the `doParseOptions` method to parse these options!
 	 */
-	optionDefinitions?: (parsedCommand?: VLazyParsedCommand) => OptionDef[];
+	optionDefinitions?: OptionDef[] | ((parsedCommand?: VLazyParsedCommand) => OptionDef[]);
 }
 
 export interface VParserOptions extends VCommonParserOptions {
@@ -58,7 +60,7 @@ function mergeWithDefaultParserOptions<T extends VCommonParserOptions>(parserOpt
  * @param parserOptions
  */
 export function verifyParserOptionsIsNonLazy(parserOptions: RequiredParserOptions<VLazyParserOptions | VParserOptions>): parserOptions is Required<VCommonParserOptions> & VParserOptions {
-	return !parserOptions.lazy && (parserOptions.optionDefinitions == undefined || Array.isArray(parserOptions.optionDefinitions));
+	return !parserOptions.lazy && (typeof parserOptions.optionDefinitions != 'function');
 }
 function verifyParsedCommandType(parsedMessage: VParsedMessage<RequiredParserOptions<VLazyParserOptions | VParserOptions>>): parsedMessage is VParsedMessage<Required<VCommonParserOptions> & VParserOptions> {
 	return verifyParserOptionsIsNonLazy(parsedMessage.parserOptions);

--- a/src/vparsedcommand.ts
+++ b/src/vparsedcommand.ts
@@ -2,7 +2,7 @@ import OptionPrefix from './@types/OptionPrefix';
 import MessageOption from './message-option';
 import { extractOptionsFromParsedContent, VParsedMessage } from './message-parser';
 import OptionDef from './option-def';
-import { RequiredParserOptions, verifyParserOptionsIsNonLazy, VLazyParserOptions, VParserOptions } from './vcommandparser';
+import { RequiredParserOptions, VLazyParserOptions, VParserOptions } from './vcommandparser';
 
 export class VCommonParsedCommand {
 	readonly isCommand: boolean;
@@ -37,7 +37,7 @@ export class VCommonParsedCommand {
 			},
 		} = parsedMessage);
 		
-		if (verifyParserOptionsIsNonLazy(parsedMessage.parserOptions)) {
+		if (typeof parsedMessage.parserOptions.optionDefinitions != 'function') {
 			this.optionDefinitions = parsedMessage.parserOptions.optionDefinitions;
 		}
 	}
@@ -107,7 +107,9 @@ export class VLazyParsedCommand extends VCommonParsedCommand {
 	constructor(message: string, parsedMessage: VParsedMessage<RequiredParserOptions<VLazyParserOptions>>) {
 		super(message, parsedMessage);
 		
-		this.optionDefinitionsGetter = parsedMessage.parserOptions.optionDefinitions;
+		if (typeof parsedMessage.parserOptions.optionDefinitions == 'function') {
+			this.optionDefinitionsGetter = parsedMessage.parserOptions.optionDefinitions;
+		}
 	}
 	
 	/**
@@ -116,7 +118,7 @@ export class VLazyParsedCommand extends VCommonParsedCommand {
 	 * This has no value if you called the `setOptionDefinitions` function before.
 	 */
 	doParseOptions(): void {
-		this.doExtractOptions(this.optionDefinitionsGetter && this.optionDefinitionsGetter(this));
+		this.doExtractOptions(this.optionDefinitions ?? (this.optionDefinitionsGetter && this.optionDefinitionsGetter(this)));
 	}
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -23,7 +23,13 @@ describe('Testing value types', () => {
 		expect(parsed instanceof VLazyParsedCommand).toBeTruthy();
 	});
 	
-	it('parsed object should be of type VLazyParsedCommand when custom optionDefs', () => {
+	it('parsed object should be of type VParsedCommand when custom optionDefs is array', () => {
+		const parsed = VCommandParser.parse('!mycommand', {optionDefinitions: []});
+		
+		expect(parsed instanceof VParsedCommand).toBeTruthy();
+	});
+	
+	it('parsed object should be of type VLazyParsedCommand when custom optionDefs is function', () => {
 		const parsed = VCommandParser.parse('!mycommand', {optionDefinitions: () => []});
 		
 		expect(parsed instanceof VLazyParsedCommand).toBeTruthy();


### PR DESCRIPTION
This change allows anyone that wants to do a lazy parsing but already knowing the option definitions to enter that in the options to the parser.